### PR TITLE
Add DELETE /user/profile endpoint

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,5 +1,6 @@
 // routes/userRoutes.js
 const express = require('express');
+const bcrypt = require('bcrypt');
 const { knex: db } = require('../db');
 const { authenticateToken } = require('../middleware/auth');
 const { AVAILABLE_FLAGS } = require('../config/constants');
@@ -167,6 +168,19 @@ router.get('/user/profile', authenticateToken, async (req, res) => {
             if (!user) return res.status(404).json({ error: 'User not found' });
             res.json({ ...user, auth_method: user.oauth_provider || 'traditional' });
         }).catch(err => res.status(500).json({ error: 'Server error' }));
+});
+
+router.delete('/user/profile', authenticateToken, async (req, res) => {
+    try {
+        const deleted = await db('users').where({ id: req.user.id }).delete();
+        if (!deleted) {
+            return res.status(404).json({ error: 'User not found' });
+        }
+        res.json({ message: 'Account deleted successfully' });
+    } catch (err) {
+        console.error('Account deletion error:', err);
+        res.status(500).json({ error: 'Failed to delete account' });
+    }
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Adds `DELETE /user/profile` route so clients can delete their account
- Fixes missing `bcrypt` import that would crash on any password change request
- Cascading deletes (scores, game_states) are handled at the DB level via existing foreign key constraints

## Test plan
- [ ] `DELETE /user/profile` with a valid auth token deletes the user and returns `{ message: 'Account deleted successfully' }`
- [ ] Related `scores` and `game_states` rows are removed automatically
- [ ] Returns 404 if user is not found
- [ ] `PUT /user/profile` password change no longer crashes (bcrypt now imported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)