### PR TITLE
fix null level and score crashing old app clients

### DIFF
--- a/routes/leaderboardRoutes.js
+++ b/routes/leaderboardRoutes.js
@@ -29,9 +29,9 @@ router.get('/leaderboard', async (req, res) => {
 
         const leaderboard = results.map(row => ({
             username: row.username,
-            score: row.score,
+            score: row.score ?? 0,
             country_flag: row.country_flag || 'international',
-            level: row.level,
+            level: row.level ?? 0,
         }));
 
         res.json(leaderboard);


### PR DESCRIPTION
## Summary
- Coerce null `level` and `score` values to `0` in the leaderboard response
- Prevents old Flutter app from crashing with `type 'Null' is not a subtype of type 'int'`

## Test plan
- [ ] Deploy to production
- [ ] Verify old app loads leaderboard without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)