### PR TITLE
Add world map progress feature

### DIFF
--- a/migrations/20260414000000_create_world_map_progress.js
+++ b/migrations/20260414000000_create_world_map_progress.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.createTable('world_map_progress', function (table) {
+        table.integer('user_id').primary().references('id').inTable('users');
+        table.text('revealed').notNullable().defaultTo('[]');
+        table.timestamp('updated_at').defaultTo(knex.fn.now());
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.dropTable('world_map_progress');
+};

--- a/routes/worldMapRoutes.js
+++ b/routes/worldMapRoutes.js
@@ -1,0 +1,75 @@
+// routes/worldMapRoutes.js
+const express = require('express');
+const { knex: db } = require('../db');
+const { authenticateToken } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.post('/world-map/progress', authenticateToken, async (req, res) => {
+    const { revealed_countries } = req.body;
+
+    if (!Array.isArray(revealed_countries)) {
+        return res.status(400).json({ error: 'revealed_countries must be an array' });
+    }
+
+    try {
+        await db('world_map_progress')
+            .insert({
+                user_id: req.user.id,
+                revealed: JSON.stringify(revealed_countries),
+                updated_at: db.fn.now(),
+            })
+            .onConflict('user_id')
+            .merge(['revealed', 'updated_at']);
+
+        res.json({ message: 'World map progress saved' });
+    } catch (err) {
+        console.error('Error saving world map progress:', err);
+        res.status(500).json({ error: 'Failed to save world map progress' });
+    }
+});
+
+router.get('/world-map/progress', authenticateToken, async (req, res) => {
+    try {
+        const row = await db('world_map_progress')
+            .where({ user_id: req.user.id })
+            .select('revealed')
+            .first();
+
+        const revealed_countries = row ? JSON.parse(row.revealed) : [];
+        res.json({ revealed_countries });
+    } catch (err) {
+        console.error('Error fetching world map progress:', err);
+        res.status(500).json({ error: 'Failed to fetch world map progress' });
+    }
+});
+
+router.get('/world-map/leaderboard', async (req, res) => {
+    const limit = parseInt(req.query.limit || '50');
+
+    try {
+        const rows = await db('world_map_progress as wmp')
+            .join('users as u', 'wmp.user_id', 'u.id')
+            .select('u.username', 'u.country_flag', 'wmp.revealed');
+
+        const leaderboard = rows
+            .map(row => {
+                const countries = JSON.parse(row.revealed || '[]');
+                return {
+                    username: row.username,
+                    country_flag: row.country_flag || 'international',
+                    countries_revealed: countries.length,
+                };
+            })
+            .filter(row => row.countries_revealed > 0)
+            .sort((a, b) => b.countries_revealed - a.countries_revealed)
+            .slice(0, limit);
+
+        res.json(leaderboard);
+    } catch (err) {
+        console.error('World map leaderboard error:', err);
+        res.status(500).json({ error: 'Failed to load world map leaderboard' });
+    }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const authRoutes = require('./routes/authRoutes');
 const userRoutes = require('./routes/userRoutes');
 const gameRoutes = require('./routes/gameRoutes');
 const leaderboardRoutes = require('./routes/leaderboardRoutes');
+const worldMapRoutes = require('./routes/worldMapRoutes');
 
 const app = express();
 
@@ -44,6 +45,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api', authenticateToken, userRoutes);
 app.use('/api', authenticateToken, gameRoutes);
 app.use('/api', leaderboardRoutes); // leaderboard might be public; keep as-is
+app.use('/api', worldMapRoutes);
 
 app.use(notFoundHandler);
 app.use(errorHandler);


### PR DESCRIPTION
## Summary
- Adds `world_map_progress` table via migration (new table only, no existing schema changes)
- Adds `GET/POST /api/world-map/progress` endpoints (authenticated) to save and retrieve revealed countries per user
- Adds `GET /api/world-map/leaderboard` public endpoint ranking users by countries revealed

## Deploy notes
Run `knex migrate:latest` on the production DB after deploying — creates the new table, does not affect any existing tables or records.

## Test plan
- [ ] `POST /api/world-map/progress` saves revealed countries for authenticated user
- [ ] `GET /api/world-map/progress` returns correct revealed countries for authenticated user
- [ ] `GET /api/world-map/leaderboard` returns ranked list without auth
- [ ] Upsert works correctly (second save overwrites first, no duplicate rows)
- [ ] Existing endpoints unaffected after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)